### PR TITLE
added eyeglass needs field to prevent errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "eyeglass-module"
   ],
   "eyeglass": {
-    "exports": "eyeglass-exports.js"
+    "exports": "eyeglass-exports.js",
+    "needs": "*"
   },
   "scripts": {
     "release": "gulp sasslint && gulp sassdoc"


### PR DESCRIPTION
Pretty self explanatory. Eyeglass was failing to load Accoutrement-init because there wasn't a "needs" value. I used "*" because that's what Chris Eppstein [recommended in a similar issue](https://github.com/sass-eyeglass/eyeglass/issues/109)
